### PR TITLE
fix: case sensitive email

### DIFF
--- a/src/modules/user/user.middlewares.ts
+++ b/src/modules/user/user.middlewares.ts
@@ -52,6 +52,21 @@ export const emailSchema: ParamSchema = {
     },
     isEmail: {
         errorMessage: USER_MESSAGES.EMAIL_IS_INVALID
+    },
+    normalizeEmail: {
+        options: {
+            all_lowercase: true,
+            gmail_lowercase: true,
+            gmail_remove_dots: true,
+            gmail_remove_subaddress: true,
+            gmail_convert_googlemaildotcom: true,
+            outlookdotcom_lowercase: true,
+            outlookdotcom_remove_subaddress: true,
+            yahoo_lowercase: true,
+            yahoo_remove_subaddress: true,
+            icloud_lowercase: true,
+            icloud_remove_subaddress: true
+        }
     }
 }
 


### PR DESCRIPTION
Normalize email address by using express-validator:
- Lowercase, remove dot, remove subaddress for all email

Ex: 
- username@gmail.com
- user.name@gmail.com
- UserName@gmail.com
- username+shopping@gmail.com
Will be treated as 1 gmail address by Google