### PR TITLE
fix/user was verified but can send otp to verify account

### DIFF
--- a/src/modules/otp/otp.controllers.ts
+++ b/src/modules/otp/otp.controllers.ts
@@ -2,10 +2,13 @@ import { Request, Response } from 'express'
 import { ParamsDictionary } from 'express-serve-static-core'
 import { StatusCodes } from 'http-status-codes'
 import otpGenerator from 'otp-generator'
-import otpService from './otp.services'
+import { HTTP_STATUS } from '~/constants/httpStatus'
+import { encrypt } from '~/utils/crypto'
+import usersService from '../user/user.services'
+import { OTP_KIND } from './otp.enum'
 import { OTP_MESSAGES } from './otp.messages'
 import { SendOtpViaMailReqBody, SendOtpViaPhoneReqBody } from './otp.requests'
-import { OTP_KIND } from './otp.enum'
+import otpService from './otp.services'
 // import { Twilio } from 'twilio'
 
 //! Config Twilio
@@ -18,6 +21,16 @@ export const sendOtpPhoneNumberController = async (
     res: Response
 ) => {
     const { phone_number } = req.body
+
+    // need to check the current account was verified or not?
+    //if verified we do not send OTP
+    if (await usersService.checkPhoneNumberIsVerified(encrypt(phone_number))) {
+        return res.status(HTTP_STATUS.BAD_REQUEST).json({
+            message: OTP_MESSAGES.PHONE_NUMBER_WAS_VERIFIED
+        })
+    }
+
+    //else send OTP
     const otp = otpGenerator.generate(6, {
         upperCaseAlphabets: false,
         lowerCaseAlphabets: false,
@@ -43,6 +56,17 @@ export const sendOtpMailController = async (
     req: Request<ParamsDictionary, any, SendOtpViaMailReqBody>,
     res: Response
 ) => {
+    const { email } = req.body
+
+    // need to check the current account was verified or not?
+    //if verified we do not send OTP
+    if (await usersService.checkEmailIsVerified(encrypt(email))) {
+        return res.status(HTTP_STATUS.BAD_REQUEST).json({
+            message: OTP_MESSAGES.EMAIL_WAS_VERIFIED
+        })
+    }
+
+    //else send OTP
     const otp = otpGenerator.generate(6, {
         upperCaseAlphabets: false,
         lowerCaseAlphabets: false,
@@ -50,7 +74,7 @@ export const sendOtpMailController = async (
     })
     //* Nhét thêm otp vào req.body
     const result = await otpService.sendEmail({
-        email: req.body.email,
+        email,
         otp,
         kind: OTP_KIND.VerifyAccount
     })

--- a/src/modules/otp/otp.messages.ts
+++ b/src/modules/otp/otp.messages.ts
@@ -6,6 +6,8 @@ export const OTP_MESSAGES = {
     SEND_OTP_MAIL_SUCCESS: 'Send OTP via mail successfully',
     SEND_OTP_OVER_LIMIT_TIME:
         'Send otp over 3 time, Please wait 24 hours to try again',
+    PHONE_NUMBER_WAS_VERIFIED: 'Phone number was verified',
+    EMAIL_WAS_VERIFIED: 'Email was verified',
 
     // USER
     USER_NOT_FOUND: 'User not found!',

--- a/src/modules/user/user.controllers.ts
+++ b/src/modules/user/user.controllers.ts
@@ -93,14 +93,13 @@ export const forgotPasswordController = async (
             })
         } else {
             result = usersService.sendForgotPasswordOTPByPhone(
-                req.body.phone_number
+                req.body.phone_numberZ
             )
         }
     }
 
     return res.status(200).json({
-        message: USER_MESSAGES.SEND_OTP_SUCCESSFULLY,
-        details: result
+        message: USER_MESSAGES.SEND_OTP_SUCCESSFULLY
     })
 }
 

--- a/src/modules/user/user.controllers.ts
+++ b/src/modules/user/user.controllers.ts
@@ -93,7 +93,7 @@ export const forgotPasswordController = async (
             })
         } else {
             result = usersService.sendForgotPasswordOTPByPhone(
-                req.body.phone_numberZ
+                req.body.phone_number
             )
         }
     }


### PR DESCRIPTION
@hoangday185 

- Solve this bug, when user is vefired we will not send OTP again, and res this message
- This account test is provided by @hoangday185 with `verify status is 1` 
![image](https://github.com/PiedTeam/NikeCloneTraining-BE-Project/assets/136492579/c20282b0-b7c9-4e38-8869-c962a33ae504)
![image](https://github.com/PiedTeam/NikeCloneTraining-BE-Project/assets/136492579/d50431e9-f835-4045-b00f-2cbde8f7731f)

- When my account have `verify status is 0`, it will send OTP, receive normally
![image](https://github.com/PiedTeam/NikeCloneTraining-BE-Project/assets/136492579/b2dcf985-18d0-471b-ba4e-7156f7bbe813)